### PR TITLE
Fix cross-platform build for BuildDSLClient

### DIFF
--- a/Sources/BuildDSLClient/main.swift
+++ b/Sources/BuildDSLClient/main.swift
@@ -6,9 +6,17 @@
 
 import BuildDSL
 import Foundation
-import os
-
+#if canImport(OSLog)
+import OSLog
 let logger = Logger(subsystem: "Examples", category: "BuildDSL")
+#else
+struct Logger {
+    init(subsystem: String, category: String) {}
+    func info(_ message: String) {}
+    func error(_ message: String) {}
+}
+let logger = Logger(subsystem: "Examples", category: "BuildDSL")
+#endif
 
 /**
  Example usages of the @Builder macro and its suplimentary @Default, @Ignore and @Escaping macros.


### PR DESCRIPTION
## Summary
- avoid importing `os` on platforms where it's unavailable
- provide minimal logger stub when `OSLog` framework can't be imported

## Testing
- `swift test`
